### PR TITLE
Remove check for contiguous instrument numbers in midi_io

### DIFF
--- a/music/src/core/midi_io.ts
+++ b/music/src/core/midi_io.ts
@@ -159,12 +159,7 @@ export function sequenceProtoToMidi(ns: INoteSequence) {
   }
   const instruments = Array.from(tracks.keys()).sort((a, b) => a - b);
   for (let i = 0; i < instruments.length; i++) {
-    if (i !== instruments[i]) {
-      throw new MidiConversionError(
-          'Instrument list must be continuous and start at 0');
-    }
-
-    const notes = tracks.get(i);
+    const notes = tracks.get(instruments[i]);
     const track = {
       id: i,
       notes: [] as Array<{}>,


### PR DESCRIPTION
I ran into this error ("Instrument list must be continuous and start at 0") when I was trying to save a `NoteSequence` from which I had removed some notes, which created a gap in the instrument numbers.

I don't see the purpose of this check, so I'm proposing to get rid of it. Looking at the history, it seems to have been there because of the way channel numbers were assigned. That is now different, so it should be safe to remove it, shouldn't it?