### PR TITLE
Fix sequences.trim

### DIFF
--- a/music/src/core/sequences.ts
+++ b/music/src/core/sequences.ts
@@ -656,15 +656,16 @@ function trimHelper(
           (truncateEndNotes || n[endKey] <= end));
 
   // Shift the sequence to start at 0.
+  result[totalKey] -= start;
   for (let i = 0; i < result.notes.length; i++) {
     result.notes[i][startKey] -= start;
     result.notes[i][endKey] -= start;
 
     if (truncateEndNotes) {
-      result.notes[i][endKey] = Math.min(result.notes[i][endKey], end);
+      result.notes[i][endKey] = Math.min(result.notes[i][endKey],
+                                         result[totalKey]);
     }
   }
-  result[totalKey] = Math.min(ns[totalKey] - start, end);
   return result;
 }
 

--- a/music/src/core/sequences_test.ts
+++ b/music/src/core/sequences_test.ts
@@ -796,7 +796,7 @@ test('Trim NoteSequence (unquantized)', (t: test.Test) => {
     [71, 100, 2.0, 3.0], [58, 100, 3.0, 4.5], [70, 100, 5.0, 5.5]
   ]);
   addTrackToSequence(expected, 0, [[59, 100, 0, 1], [71, 100, 0.5, 1.5]]);
-  expected.totalTime = 4;
+  expected.totalTime = 2.5;
 
   t.deepEqual(
       NoteSequence.toObject(sequences.trim(ns1, 1.5, 4.0)),
@@ -813,8 +813,8 @@ test('Trim and truncate NoteSequence (unquantized)', (t: test.Test) => {
     [71, 100, 2.0, 3.0], [58, 100, 3.0, 4.5], [70, 100, 5.0, 5.5]
   ]);
   addTrackToSequence(
-      expected, 0, [[59, 100, 0, 1], [71, 100, 0.5, 1.5], [58, 100, 1.5, 3.0]]);
-  expected.totalTime = 4;
+      expected, 0, [[59, 100, 0, 1], [71, 100, 0.5, 1.5], [58, 100, 1.5, 2.5]]);
+  expected.totalTime = 2.5;
 
   t.deepEqual(
       NoteSequence.toObject(sequences.trim(ns1, 1.5, 4.0, true)),
@@ -834,7 +834,7 @@ test('Trim NoteSequence (quantized)', (t: test.Test) => {
   expected.quantizationInfo = NoteSequence.QuantizationInfo.create(
       {stepsPerQuarter: STEPS_PER_QUARTER});
   addQuantizedTrackToSequence(expected, 0, [[60, 100, 1, 2], [60, 100, 2, 3]]);
-  expected.totalQuantizedSteps = 5;
+  expected.totalQuantizedSteps = 4;
 
   t.deepEqual(
       NoteSequence.toObject(sequences.trim(ns1, 1, 5)),
@@ -854,7 +854,7 @@ test('Trim and truncate NoteSequence (quantized)', (t: test.Test) => {
   expected.quantizationInfo = NoteSequence.QuantizationInfo.create(
       {stepsPerQuarter: STEPS_PER_QUARTER});
   addQuantizedTrackToSequence(
-      expected, 0, [[60, 100, 1, 2], [60, 100, 2, 3], [60, 100, 2, 5]]);
+      expected, 0, [[60, 100, 1, 2], [60, 100, 2, 3], [60, 100, 2, 4]]);
 
   t.deepEqual(
       NoteSequence.toObject(sequences.trim(ns1, 1, 5, true)),


### PR DESCRIPTION
`trim` was using the unshifted `end` time for note truncation and for setting `totalTime`.