### PR TITLE
More CSS-friendly SVG visualizers

### DIFF
--- a/music/demos/style.css
+++ b/music/demos/style.css
@@ -44,16 +44,18 @@ button, .button {
   font-size: 16px;
   padding: 4px 14px;
   margin-right: 8px;
-  border: 3px solid #222;
   background: transparent;
-  outline: none;
-  color: #222;
-  background: white;
   cursor: pointer;
 }
-button:hover {
+button:hover, .button:hover {
   background: #6FC9C6;
   color: white;
+}
+button, .button, textarea {
+  outline: none;
+  border: 3px solid #222;
+  color: #222;
+  background: white;
 }
 
 .player-container {

--- a/music/demos/visualizer.html
+++ b/music/demos/visualizer.html
@@ -25,6 +25,14 @@ limitations under the License.
       cursor: pointer;
       display: none;
     }
+
+    textarea {
+      display: block;
+      margin-bottom: 4px;
+    }
+  </style>
+
+  <style id="customStyle">
   </style>
 </head>
 <body>
@@ -52,7 +60,7 @@ limitations under the License.
     </span>
   </section>
 
-  <h2>mm.PianoRollSVGVisualizer</h2>
+  <h2 id="PianoRollSVGVisualizer">mm.PianoRollSVGVisualizer</h2>
   <section>
     <div class="visualizer-container">
       <svg id="svg"></svg>
@@ -91,6 +99,43 @@ limitations under the License.
     </div>
   </section>
 
+  <h2>Styling SVG visualizers</h2>
+  <section>
+    <p>
+      SVG visualizers (piano roll and waterfall) support CSS! Use a selector like
+      <code>svg rect.note</code> to match notes, and style them using the
+      <a href="https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Presentation">
+        available CSS properties</a>. More advanced styling is possible:
+      <ul>
+        <li>Currently playing notes can be matched using the <code>.active</code> class.</li>
+        <li>Notes can also be matched based on properties like instrument or pitch (using
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors">
+              attribute selectors</a>), thanks to the
+            data attributes <code>data-instrument</code>, <code>data-program</code>,
+            <code>data-is-drum</code> and <code>data-pitch</code>.</li>
+        <li>A <code>--midi-velocity</code> custom property is defined on every note and can be
+            accessed using the
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/var">
+              <code>var()</code> CSS function</a>.</li>
+      </ul>
+    </p>
+    <p>
+      To demonstrate this, we need a slightly juiced up version of our <code>NoteSequence</code>:
+      <button id="seqVelBtn">Load</button>
+    </p>
+    <p>Click below to apply the following style sheet:
+    <textarea id="styleInput" rows="10" cols="100">
+svg rect.note {
+  fill: rgb(calc(var(--midi-velocity) * 1.2 + 100), 30, calc(255 - var(--midi-velocity)));
+}
+
+svg rect.note.active {
+  stroke: black;
+  stroke-width: 1.5;
+  stroke-opacity: 0.5;
+}</textarea>
+    <button id="applyStyleBtn">Apply</button></p>
+  </section>
 
   <script src="visualizer_bundle.js"></script>
 </body>

--- a/music/demos/visualizer.ts
+++ b/music/demos/visualizer.ts
@@ -42,6 +42,7 @@ const player = new mm.SoundFontPlayer(
 const playBtn = document.getElementById('playBtn') as HTMLButtonElement;
 const urlBtn = document.getElementById('urlBtn') as HTMLButtonElement;
 const seqBtn = document.getElementById('seqBtn') as HTMLButtonElement;
+const seqVelBtn = document.getElementById('seqVelBtn') as HTMLButtonElement;
 const tempoInput = document.getElementById('tempoInput') as HTMLInputElement;
 const tempoValue = document.getElementById('tempoValue') as HTMLDivElement;
 const fileInput = document.getElementById('fileInput') as HTMLInputElement;
@@ -51,6 +52,9 @@ const waterfall = document.querySelector('#waterfall') as HTMLDivElement;
 const staff = document.getElementById('staff') as HTMLDivElement;
 const waterfallCheckbox =
     document.getElementById('waterfallCheckbox') as HTMLInputElement;
+const styleInput = document.getElementById('styleInput') as HTMLTextAreaElement;
+const applyStyleBtn = document.getElementById('applyStyleBtn') as HTMLButtonElement;
+const customStyle = document.getElementById('customStyle') as HTMLStyleElement;
 
 // Set up some event listeners
 urlBtn.addEventListener('click', () => fetchMidi(MIDI_URL));
@@ -71,6 +75,17 @@ waterfallCheckbox.addEventListener('change', () => {
         currentSequence, waterfall,
         {showOnlyOctavesUsed: waterfallCheckbox.checked});
   }
+});
+seqVelBtn.addEventListener('click', () => {
+  const ns = mm.sequences.clone(FULL_TWINKLE_UNQUANTIZED);
+  for (const note of ns.notes) {
+    note.velocity = Math.round((Math.sin(note.startTime) + 1.5) / 2.5 * 120);
+  }
+  initPlayerAndVisualizer(ns);
+});
+applyStyleBtn.addEventListener('click', () => {
+  customStyle.textContent = styleInput.value;
+  document.getElementById('PianoRollSVGVisualizer').scrollIntoView();
 });
 
 function fetchMidi(url: string) {

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -339,9 +339,10 @@ export class Visualizer extends PianoRollCanvasVisualizer {
 }
 
 /**
- * HTML data attribute key-value pair.
+ * HTML/CSS key-value pairs.
  */
 type DataAttribute = [string, any];  // tslint:disable-line:no-any
+type CSSProperty = [string, string | null];
 
 /**
  * Abstract base class for a `NoteSequence` visualizer.
@@ -438,8 +439,13 @@ export abstract class BaseSVGVisualizer extends BaseVisualizer {
         ['isDrum', note.isDrum === true],
         ['pitch', note.pitch],
       ];
+      const cssProperties: CSSProperty[] = [
+        ['--midi-velocity',
+         String(note.velocity !== undefined ? note.velocity : 127)]
+      ];
 
-      this.drawNote(size.x, size.y, size.w, size.h, fill, dataAttributes);
+      this.drawNote(size.x, size.y, size.w, size.h, fill,
+                    dataAttributes, cssProperties);
     }
     this.drawn = true;
   }
@@ -455,12 +461,13 @@ export abstract class BaseSVGVisualizer extends BaseVisualizer {
 
   private drawNote(
       x: number, y: number, w: number, h: number, fill: string,
-      dataAttributes: DataAttribute[]) {
+      dataAttributes: DataAttribute[], cssProperties: CSSProperty[]) {
     if (!this.svg) {
       return;
     }
     const rect: SVGRectElement =
         document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.classList.add('note');
     rect.setAttribute('fill', fill);
 
     // Round values to the nearest integer to avoid partially filled pixels.
@@ -472,6 +479,9 @@ export abstract class BaseSVGVisualizer extends BaseVisualizer {
       if (value !== undefined) {
         rect.dataset[key] = `${value}`;
       }
+    });
+    cssProperties.forEach(([key, value]: CSSProperty) => {
+      rect.style.setProperty(key, value);
     });
     this.svg.appendChild(rect);
   }


### PR DESCRIPTION
Adding `class="note"` and a `--midi-velocity` CSS variable.

This is now possible:
```css
svg rect.note {
  fill: #28f;
  opacity: calc(var(--midi-velocity) / 127);
}
```
![image](https://user-images.githubusercontent.com/8046580/86158238-cb1c8d80-bb08-11ea-8547-1c4518b5185b.png)


Or even:
```css
svg rect.note {
  fill: rgb(calc((var(--midi-velocity) - 64) * 4), 30, calc(255 - var(--midi-velocity)));
}
```
![image](https://user-images.githubusercontent.com/8046580/86158255-d079d800-bb08-11ea-93f5-52e03c74c821.png)
