### PR TITLE
Add new timer module for performance.now shim

### DIFF
--- a/music/README.md
+++ b/music/README.md
@@ -96,10 +96,9 @@ The node-specific bundles (that don't transpile the CommonJS modules) are under
 const model = require('@magenta/music/node/music_vae');
 const core = require('@magenta/music/node/core');
 
-// These hacks below are needed because the library uses performance and fetch which
-// exist in browsers but not in node. We are working on simplifying this!
+// These hacks below are needed because the library uses fetch which
+// exists in browsers but not in node. We are working on simplifying this!
 const globalAny: any = global;
-globalAny.performance = Date;
 globalAny.fetch = require('node-fetch');
 
 // Your code:

--- a/music/demos/coconet.ts
+++ b/music/demos/coconet.ts
@@ -20,7 +20,7 @@ import * as tf from '@tensorflow/tfjs-core';
 import {mergeConsecutiveNotes, replaceInstruments} from '../src/core/sequences';
 import * as mm from '../src/index';
 import {NoteSequence} from '../src/index';
-import * as timer from '../src/timer';
+import * as timer from '../src/core/timer';
 
 // tslint:disable-next-line:max-line-length
 import {CHECKPOINTS_DIR, MEL_TWINKLE, writeMemory, writeNoteSeqs, writeTimer} from './common';

--- a/music/demos/coconet.ts
+++ b/music/demos/coconet.ts
@@ -20,6 +20,7 @@ import * as tf from '@tensorflow/tfjs-core';
 import {mergeConsecutiveNotes, replaceInstruments} from '../src/core/sequences';
 import * as mm from '../src/index';
 import {NoteSequence} from '../src/index';
+import * as timer from '../src/timer';
 
 // tslint:disable-next-line:max-line-length
 import {CHECKPOINTS_DIR, MEL_TWINKLE, writeMemory, writeNoteSeqs, writeTimer} from './common';
@@ -29,7 +30,7 @@ async function infillFirstVoice() {
   await model.initialize();
   writeNoteSeqs('input-1', [MEL_TWINKLE], true);
 
-  const start = performance.now();
+  const start = timer.now();
   const output = await model.infill(MEL_TWINKLE);
   // Optionally, merge the held notes and restore the original melody timing
   // since the model chunks up the melody in 16ths.
@@ -50,7 +51,7 @@ async function infillSecondVoice() {
   }
   writeNoteSeqs('input-2', [ns], true);
 
-  const start = performance.now();
+  const start = timer.now();
   // A smaller temperature means the output is more random. Fewer sampling
   // iterations means the process is faster, but the results are less good.
   const output = await model.infill(ns, {temperature: 0.5, numIterations: 10});
@@ -98,7 +99,7 @@ async function infillSection() {
   }
   writeNoteSeqs('input-3', [ns], true);
 
-  const start = performance.now();
+  const start = timer.now();
   const output = await model.infill(ns, {infillMask: mask});
 
   // Optionally, treat any consecutive notes as merged.

--- a/music/demos/common.ts
+++ b/music/demos/common.ts
@@ -18,6 +18,7 @@
 import {saveAs} from 'file-saver';
 import * as mm from '../src/index';
 import {sequences} from '../src/core/index';
+import * as timer from '../src/core/timer';
 
 export const CHECKPOINTS_DIR =
     'https://storage.googleapis.com/magentadata/js/checkpoints';
@@ -424,7 +425,7 @@ mm.sequences.concatenate([DRUM_SEQS[0], DRUM_SEQS[0]], [32, 32])
 
 export function writeTimer(elementId: string, startTime: number) {
   document.getElementById(elementId).innerHTML =
-      ((performance.now() - startTime) / 1000).toString() + 's';
+      ((timer.now() - startTime) / 1000).toString() + 's';
 }
 
 export function writeNoteSeqs(

--- a/music/demos/gansynth.ts
+++ b/music/demos/gansynth.ts
@@ -16,6 +16,7 @@
  */
 import * as tf from '@tensorflow/tfjs';
 import * as Tone from 'tone';
+import * as timer from '../src/core/timer';
 
 import * as mm from '../src/index';
 
@@ -48,7 +49,7 @@ async function runGANSynth() {
   const gansynth = new mm.GANSynth(GANSYNTH_CHECKPOINT);
   await gansynth.initialize();
 
-  const start = await performance.now();
+  const start = timer.now();
   const specgrams = await gansynth.randomSample(60);
   const audio = await gansynth.specgramsToAudio(specgrams);
   await writeTimer('single-sample-gen-time', start);

--- a/music/demos/groovae.ts
+++ b/music/demos/groovae.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import * as mm from '../src/index';
+import * as timer from '../src/core/timer';
 
 import {CHECKPOINTS_DIR, DRUM_SEQS, writeMemory} from './common';
 import {writeNoteSeqs, writeTimer} from './common';
@@ -32,14 +33,14 @@ async function runHumanize() {
   const mvae = new mm.MusicVAE(HUMANIZE_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const z = await mvae.encode(inputs);
   const recon = await mvae.decode(z);
   z.dispose();
   writeTimer('humanize-recon-time', start);
   writeNoteSeqs('humanize-recon', recon, true, true);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('humanize-sample-time', start);
   writeNoteSeqs('humanize-samples', sample, true, true);
@@ -57,14 +58,14 @@ async function runTap2Drum() {
           mvae.dataConverter.toNoteSequence(mvae.dataConverter.toTensor(ns))));
   writeNoteSeqs('tap2drum-inputs', inputs, true);
 
-  let start = performance.now();
+  let start = timer.now();
   const z = await mvae.encode(inputs);
   const recon = await mvae.decode(z);
   z.dispose();
   writeTimer('tap2drum-recon-time', start);
   writeNoteSeqs('tap2drum-recon', recon, true, true);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('tap2drum-sample-time', start);
   writeNoteSeqs('tap2drum-samples', sample, true, true);

--- a/music/demos/melody_controls.ts
+++ b/music/demos/melody_controls.ts
@@ -19,6 +19,7 @@ import * as tf from '@tensorflow/tfjs';
 
 import * as mm from '../src/index';
 import {INoteSequence} from '../src/index';
+import * as timer from '../src/core/timer';
 
 import {CHECKPOINTS_DIR, MEL_TEAPOT, MEL_TWINKLE} from './common';
 import {writeMemory, writeNoteSeqs, writeTimer} from './common';
@@ -71,7 +72,7 @@ async function runMelControls() {
   const teapotRhythm = RHYTHM.extract(teapotMel);
   const teapotShape = SHAPE.extract(teapotMel);
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(inputs, 5, null, {
     chordProgression: ['A'],
     extraControls: {rhythm: teapotRhythm, shape: teapotShape}
@@ -79,7 +80,7 @@ async function runMelControls() {
   writeTimer('mel-controls-interp-time', start);
   writeNoteSeqs('mel-controls-interp', interp);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4, null, {
     chordProgression: ['C'],
     extraControls: {rhythm: DOTTED_RHYTHM, shape: UDUDF_SHAPE}
@@ -97,19 +98,19 @@ async function runMelRhythm() {
   const mvae = new mm.MusicVAE(MEL_RHYTHM_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(inputs, 5);
   writeTimer('mel-rhythm-interp-time', start);
   writeNoteSeqs('mel-rhythm-interp', interp);
 
   const source = MEL_TEAPOT;
   writeNoteSeqs('mel-rhythm-source', [source]);
-  start = performance.now();
+  start = timer.now();
   const similar = await mvae.similar(source, 4, 0.8);
   writeTimer('mel-rhythm-similar-time', start);
   writeNoteSeqs('mel-rhythm-similar', similar);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('mel-rhythm-sample-time', start);
   writeNoteSeqs('mel-rhythm-samples', sample);
@@ -124,19 +125,19 @@ async function runMelShape() {
   const mvae = new mm.MusicVAE(MEL_SHAPE_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(inputs, 5);
   writeTimer('mel-shape-interp-time', start);
   writeNoteSeqs('mel-shape-interp', interp);
 
   const source = MEL_TEAPOT;
   writeNoteSeqs('mel-shape-source', [source]);
-  start = performance.now();
+  start = timer.now();
   const similar = await mvae.similar(source, 4, 0.8);
   writeTimer('mel-shape-similar-time', start);
   writeNoteSeqs('mel-shape-similar', similar);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('mel-shape-sample-time', start);
   writeNoteSeqs('mel-shape-samples', sample);
@@ -155,7 +156,7 @@ async function runMelMulti() {
     mvaeShape.initialize()
   ]);
 
-  let start = performance.now();
+  let start = timer.now();
 
   const rhythmTensors = await mvaeRhythm.sampleTensors(1);
   const shapeTensors = await mvaeShape.sampleTensors(1);
@@ -190,7 +191,7 @@ async function runMelMulti() {
       'mel-multi-key-seqs',
       [melodySeqsIonian[0], melodySeqsLydian[0], melodySeqsMixolydian[0]]);
 
-  start = performance.now();
+  start = timer.now();
 
   const z = await mvaeMel.encode(
       melodySeqs, {chordProgression: ['C'], extraControls});

--- a/music/demos/midi_me.ts
+++ b/music/demos/midi_me.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import * as mm from '../src/index';
+import * as timer from '../src/core/timer';
 import {blobToNoteSequence, MidiMe, MusicVAE, NoteSequence} from '../src/index';
 import {quantizeNoteSequence} from '../src/core/sequences';
 
@@ -86,7 +87,7 @@ function trainTrio() {
 
 async function train(
     mel: NoteSequence[], vae: MusicVAE, midime: MidiMe, prefix: string) {
-  const start = performance.now();
+  const start = timer.now();
 
   // 1. Encode the input into MusicVAE, get back a z.
   const quantizedMels: NoteSequence[] = [];

--- a/music/demos/multitrack.ts
+++ b/music/demos/multitrack.ts
@@ -19,6 +19,7 @@ import * as tf from '@tensorflow/tfjs';
 import * as clone from 'clone';
 
 import * as mm from '../src/index';
+import * as timer from '../src/core/timer';
 
 import {CHECKPOINTS_DIR, DRUM_SEQS, MEL_TWINKLE, writeMemory} from './common';
 import {writeNoteSeqs, writeTimer} from './common';
@@ -63,14 +64,14 @@ async function runMultitrack() {
   const mvae = new mm.MusicVAE(MULTITRACK_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const z = await mvae.encode(inputs);
   const recon = await mvae.decode(z, null, null, 24);
   z.dispose();
   writeTimer('multitrack-recon-time', start);
   writeNoteSeqs('multitrack-recon', recon, true);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4, null, null, 24);
   writeTimer('multitrack-sample-time', start);
   writeNoteSeqs('multitrack-samples', sample, true);
@@ -85,14 +86,14 @@ async function runMultitrackChords() {
   const mvae = new mm.MusicVAE(MULTITRACK_CHORDS_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const z = await mvae.encode(inputs, {chordProgression: ['C']});
   const recon = await mvae.decode(z, null, {chordProgression: ['G']}, 24);
   z.dispose();
   writeTimer('multitrack-chords-recon-time', start);
   writeNoteSeqs('multitrack-chords-recon', recon, true);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4, null, {chordProgression: ['D']}, 24);
   writeTimer('multitrack-chords-sample-time', start);
   writeNoteSeqs('multitrack-chords-samples', sample, true);

--- a/music/demos/music_rnn.ts
+++ b/music/demos/music_rnn.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import * as mm from '../src/index';
+import * as timer from '../src/core/timer';
 
 import {CHECKPOINTS_DIR} from './common';
 import {writeMemory, writeNoteSeqs, writeTimer} from './common';
@@ -122,7 +123,7 @@ async function runMelodyRnn() {
   const melodyRnn = new mm.MusicRNN(MEL_CHECKPOINT);
   await melodyRnn.initialize();
 
-  const start = performance.now();
+  const start = timer.now();
   const continuation = await melodyRnn.continueSequence(qns, 20);
   writeTimer('melody-cont-time', start);
   writeNoteSeqs('melody-cont-results', [continuation]);
@@ -137,7 +138,7 @@ async function runDrumsRnn() {
   const drumsRnn = new mm.MusicRNN(DRUMS_CHECKPOINT);
   await drumsRnn.initialize();
 
-  const start = performance.now();
+  const start = timer.now();
   const continuation = await drumsRnn.continueSequence(qns, 20);
   writeTimer('drums-cont-time', start);
   writeNoteSeqs('drums-cont-results', [continuation]);
@@ -152,7 +153,7 @@ async function runImprovRnn() {
   const improvRnn = new mm.MusicRNN(IMPROV_CHECKPOINT);
   await improvRnn.initialize();
 
-  const start = performance.now();
+  const start = timer.now();
   const continuation = await improvRnn.continueSequence(qns, 20, 1.0, ['Cm']);
   writeTimer('improv-cont-time', start);
   writeNoteSeqs('improv-cont-results', [continuation]);

--- a/music/demos/music_vae.ts
+++ b/music/demos/music_vae.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import * as mm from '../src/index';
+import * as timer from '../src/core/timer';
 
 import {CHECKPOINTS_DIR, TRIO_EXAMPLE, writeMemory} from './common';
 import {DRUM_SEQS, MEL_A_QUARTERS, MEL_TEAPOT, MEL_TWINKLE} from './common';
@@ -38,12 +39,12 @@ async function runDrums() {
   const mvae = new mm.MusicVAE(DRUMS_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(DRUM_SEQS, 3);
   writeTimer('drums-interp-time', start);
   writeNoteSeqs('drums-interp', interp);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('drums-sample-time', start);
   writeNoteSeqs('drums-samples', sample);
@@ -57,12 +58,12 @@ async function runDrumsNade() {
   const mvae = new mm.MusicVAE(DRUMS_NADE_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(DRUM_SEQS, 3);
   writeTimer('nade-interp-time', start);
   writeNoteSeqs('nade-interp', interp);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('nade-sample-time', start);
   writeNoteSeqs('nade-samples', sample);
@@ -77,12 +78,12 @@ async function runMel() {
   const mvae = new mm.MusicVAE(MEL_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(inputs, 5);
   writeTimer('mel-interp-time', start);
   writeNoteSeqs('mel-interp', interp);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('mel-sample-time', start);
   writeNoteSeqs('mel-samples', sample);
@@ -97,13 +98,13 @@ async function runMelChords() {
   const mvae = new mm.MusicVAE(MEL_CHORDS_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(
       inputs, 5, null, {chordProgression: ['A', 'A', 'D', 'A']});
   writeTimer('mel-chords-interp-time', start);
   writeNoteSeqs('mel-chords-interp', interp);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4, null, {chordProgression: ['C']});
   writeTimer('mel-chords-sample-time', start);
   writeNoteSeqs('mel-chords-samples', sample);
@@ -132,12 +133,12 @@ async function runMel16() {
   const mvae = new mm.MusicVAE(MEL_16_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const interp = await mvae.interpolate(inputs, 5);
   writeTimer('mel16-interp-time', start);
   writeNoteSeqs('mel16-interp', interp);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('mel16-sample-time', start);
   writeNoteSeqs('mel16-samples', sample);
@@ -153,14 +154,14 @@ async function runTrio() {
   const mvae = new mm.MusicVAE(TRIO_CKPT);
   await mvae.initialize();
 
-  let start = performance.now();
+  let start = timer.now();
   const z = await mvae.encode(inputs);
   const recon = await mvae.decode(z);
   z.dispose();
   writeTimer('trio-recon-time', start);
   writeNoteSeqs('trio-recon', recon);
 
-  start = performance.now();
+  start = timer.now();
   const sample = await mvae.sample(4);
   writeTimer('trio-sample-time', start);
   writeNoteSeqs('trio-samples', sample);

--- a/music/demos/transcription.ts
+++ b/music/demos/transcription.ts
@@ -19,6 +19,7 @@ import * as tf from '@tensorflow/tfjs';
 import * as MediaRecorder from 'audio-recorder-polyfill';
 
 import * as mm from '../src/index';
+import * as timer from '../src/core/timer';
 import {INoteSequence} from '../src/index';
 
 // tslint:disable-next-line:max-line-length
@@ -114,7 +115,7 @@ async function transcribe(oaf: mm.OnsetsAndFrames, chunkLength: number) {
   const melSpec: number[][] =
       await fetch(MEL_SPEC_URL).then((response) => response.json());
 
-  const start = performance.now();
+  const start = timer.now();
   oaf.chunkLength = chunkLength;
   const ns = await oaf.transcribeFromMelSpec(melSpec);
   writeTimer(`${chunkLength}-time`, start);
@@ -126,7 +127,7 @@ async function transcribe(oaf: mm.OnsetsAndFrames, chunkLength: number) {
 }
 
 async function transcribeFromAudio(oaf: mm.OnsetsAndFrames) {
-  const start = performance.now();
+  const start = timer.now();
   const ns = await oaf.transcribeFromAudioURL(ORIGINAL_AUDIO_URL);
   writeTimer('audio-time', start);
   writeNoteSeqs('audio-results', [ns], true, true);
@@ -147,7 +148,7 @@ async function transcribeFromFile(blob: Blob, prefix = 'file') {
   const oafA = new mm.OnsetsAndFrames(CKPT_URL);
   oafA.initialize()
       .then(async () => {
-        const start = performance.now();
+        const start = timer.now();
         const ns = await oafA.transcribeFromAudioFile(blob);
         writeTimer(`${prefix}-time`, start);
         writeNoteSeqs(`${prefix}-results`, [ns], true, true);

--- a/music/src/coconet/model.ts
+++ b/music/src/coconet/model.ts
@@ -22,6 +22,7 @@ import * as tf from '@tensorflow/tfjs-core';
 
 import * as logging from '../core/logging';
 import * as sequences from '../core/sequences';
+import * as timer from '../core/timer';
 import {INoteSequence} from '../protobuf/index';
 
 import {IS_IOS, NUM_PITCHES, pianorollToSequence, sequenceToPianoroll} from './coconet_utils';
@@ -335,7 +336,7 @@ class Coconet {
   async initialize() {
     this.dispose();
 
-    const startTime = performance.now();
+    const startTime = timer.now();
     this.instantiateFromSpec();
     const vars = await fetch(`${this.checkpointURL}/weights_manifest.json`)
                      .then((response) => response.json())

--- a/music/src/core/logging.ts
+++ b/music/src/core/logging.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import * as timer from './timer';
+
 /**
  * The different verbosity levels.
  */
@@ -65,6 +67,6 @@ export function log(msg: string, prefix = 'Magenta.js', level = Level.INFO) {
  */
 export function logWithDuration(
     msg: string, startTime: number, prefix = 'Magenta.js', level = Level.INFO) {
-  const durationSeconds = (performance.now() - startTime) / 1000;
+  const durationSeconds = (timer.now() - startTime) / 1000;
   log(`${msg} in ${durationSeconds.toPrecision(3)}s`, prefix, level);
 }

--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -28,6 +28,7 @@ import {sequences} from '.';
 import * as constants from './constants';
 import {DEFAULT_DRUM_PITCH_CLASSES} from './data';
 import * as soundfont from './soundfont';
+import * as timer from './timer';
 
 function compareQuantizedNotes(a: NoteSequence.INote, b: NoteSequence.INote) {
   if (a.quantizedStartStep < b.quantizedStartStep) {
@@ -724,7 +725,7 @@ export class MIDIPlayer extends BasePlayer {
     for (let i = 0; i < outputs.length; i++) {
       this.sendMessageToOutput(outputs[i], msgOn);
       this.sendMessageToOutput(
-          outputs[i], msgOff, window.performance.now() + length);
+          outputs[i], msgOff, timer.now() + length);
     }
   }
 

--- a/music/src/core/recorder.ts
+++ b/music/src/core/recorder.ts
@@ -25,6 +25,7 @@ import {NoteSequence} from '../protobuf/index';
 import {DEFAULT_QUARTERS_PER_MINUTE} from './constants';
 
 import * as logging from './logging';
+import * as timer from './timer';
 
 /**
  * An interface for providing configurable properties to a Recorder.
@@ -318,7 +319,7 @@ export class Recorder {
     if (event.timeStamp !== undefined && event.timeStamp !== 0) {
       timeStampOffset = event.timeStamp;
     } else {
-      timeStampOffset = performance.now();
+      timeStampOffset = timer.now();
     }
     const timeStamp = timeStampOffset + performance.timing.navigationStart;
 

--- a/music/src/core/timer.ts
+++ b/music/src/core/timer.ts
@@ -1,0 +1,21 @@
+/**
+ * A module containing a metronome based on Tone.js. The timing is done
+ * using the underlying WebAudio clock, so it is accurate, and the metronome
+ * fires callbacks for every audible click, quarter and bar marks.
+ *
+ * @license
+ * Copyright 2012 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const now = performance.now;

--- a/music/src/core/timer.ts
+++ b/music/src/core/timer.ts
@@ -4,7 +4,7 @@
  * fires callbacks for every audible click, quarter and bar marks.
  *
  * @license
- * Copyright 2012 Google Inc. All Rights Reserved.
+ * Copyright 2020 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/music/src/core/timer_node.ts
+++ b/music/src/core/timer_node.ts
@@ -1,0 +1,27 @@
+/**
+ * A module containing a metronome based on Tone.js. The timing is done
+ * using the underlying WebAudio clock, so it is accurate, and the metronome
+ * fires callbacks for every audible click, quarter and bar marks.
+ *
+ * @license
+ * Copyright 2012 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const NS_PER_SEC = 1e9;
+const time = process.hrtime();
+
+export const now = () => {
+  const diff = process.hrtime(time);
+  return diff[0] + diff[1] / NS_PER_SEC;
+};

--- a/music/src/core/timer_node.ts
+++ b/music/src/core/timer_node.ts
@@ -4,7 +4,7 @@
  * fires callbacks for every audible click, quarter and bar marks.
  *
  * @license
- * Copyright 2012 Google Inc. All Rights Reserved.
+ * Copyright 2020 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/music/src/gansynth/model.ts
+++ b/music/src/gansynth/model.ts
@@ -23,6 +23,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import * as logging from '../core/logging';
+import * as timer from '../core/timer';
 import {specgramsToAudio} from './audio_utils';
 import {boxUpscale, initialPad, pixelNorm} from './custom_layers';
 
@@ -53,7 +54,7 @@ class GANSynth {
    * Loads variables from the checkpoint and builds the model graph.
    */
   async initialize() {
-    const startTime = performance.now();
+    const startTime = timer.now();
     const vars = await fetch(`${this.checkpointURL}/weights_manifest.json`)
                      .then((response) => response.json())
                      .then(

--- a/music/src/music_rnn/model.ts
+++ b/music/src/music_rnn/model.ts
@@ -27,6 +27,7 @@ import * as chords from '../core/chords';
 import * as data from '../core/data';
 import * as logging from '../core/logging';
 import * as sequences from '../core/sequences';
+import * as timer from '../core/timer';
 import {INoteSequence} from '../protobuf/index';
 
 import {ATTENTION_PREFIX, AttentionWrapper} from './attention';
@@ -125,7 +126,7 @@ export class MusicRNN {
    */
   async initialize() {
     this.dispose();
-    const startTime = performance.now();
+    const startTime = timer.now();
 
     if (!this.spec) {
       await fetch(`${this.checkpointURL}/config.json`)
@@ -252,7 +253,7 @@ export class MusicRNN {
       await this.initialize();
     }
 
-    const startTime = performance.now();
+    const startTime = timer.now();
 
     const oh = tf.tidy(() => {
       const inputs = this.dataConverter.toTensor(sequence);

--- a/music/src/music_vae/midi_me.ts
+++ b/music/src/music_vae/midi_me.ts
@@ -20,6 +20,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import * as logging from '../core/logging';
+import * as timer from '../core/timer';
 export {MidiMe};
 
 /**
@@ -125,7 +126,7 @@ class MidiMe {
   initialize() {
     this.dispose();
 
-    const startTime = performance.now();
+    const startTime = timer.now();
     const x = tf.input({shape: [this.config['input_size']]});
 
     // Encoder model, goes from the original input, returns an output.
@@ -150,7 +151,7 @@ class MidiMe {
    * training epoch, containing the training errors for that epoch.
    */
   async train(xTrain: tf.Tensor, callback?: Function) {
-    const startTime = performance.now();
+    const startTime = timer.now();
     this.trained = false;
 
     // On float16 devices, use a smaller learning rate to avoid NaNs.

--- a/music/src/music_vae/model.ts
+++ b/music/src/music_vae/model.ts
@@ -26,6 +26,7 @@ import * as chords from '../core/chords';
 import * as constants from '../core/constants';
 import * as data from '../core/data';
 import * as logging from '../core/logging';
+import * as timer from '../core/timer';
 import {INoteSequence} from '../protobuf/index';
 
 /**
@@ -784,7 +785,7 @@ class MusicVAE {
    */
   async initialize() {
     this.dispose();
-    const startTime = performance.now();
+    const startTime = timer.now();
 
     if (!this.spec) {
       await fetch(`${this.checkpointURL}/config.json`)
@@ -1271,7 +1272,7 @@ class MusicVAE {
       await this.initialize();
     }
 
-    const startTime = performance.now();
+    const startTime = timer.now();
 
     const inputTensors = tf.tidy(
         () => tf.stack(inputSequences.map(
@@ -1348,7 +1349,7 @@ class MusicVAE {
     if (!this.initialized) {
       await this.initialize();
     }
-    const startTime = performance.now();
+    const startTime = timer.now();
     const numSteps = this.dataConverter.numSteps;
 
     const ohSeqs: tf.Tensor2D[] = tf.tidy(() => {
@@ -1467,7 +1468,7 @@ class MusicVAE {
     if (!this.initialized) {
       await this.initialize();
     }
-    const startTime = performance.now();
+    const startTime = timer.now();
 
     const randZs: tf.Tensor2D =
         tf.tidy(() => tf.randomNormal([numSamples, this.decoder.zDims]));

--- a/music/src/transcription/model.ts
+++ b/music/src/transcription/model.ts
@@ -24,6 +24,7 @@ import * as tf from '@tensorflow/tfjs';
 
 import {loadAudioFromFile, loadAudioFromUrl} from '../core/audio_utils';
 import * as logging from '../core/logging';
+import * as timer from '../core/timer';
 import {INoteSequence} from '../protobuf/index';
 
 import {preprocessAudio} from './audio_utils';
@@ -63,7 +64,7 @@ class OnsetsAndFrames {
    */
   async initialize() {
     this.dispose();
-    const startTime = performance.now();
+    const startTime = timer.now();
 
     const vars = await fetch(`${this.checkpointURL}/weights_manifest.json`)
                      .then((response) => response.json())
@@ -115,7 +116,7 @@ class OnsetsAndFrames {
     if (!this.isInitialized()) {
       this.initialize();
     }
-    const startTime = performance.now();
+    const startTime = timer.now();
     logging.log(
         'Computing onsets, frames, and velocities...', 'O&F',
         logging.Level.DEBUG);
@@ -148,7 +149,7 @@ class OnsetsAndFrames {
    * @returns A `NoteSequence` containing the transcribed piano performance.
    */
   async transcribeFromAudioBuffer(audioBuffer: AudioBuffer, batchSize = 4) {
-    const startTime = performance.now();
+    const startTime = timer.now();
     const melSpec = preprocessAudio(audioBuffer);
     melSpec.then(
         () => logging.logWithDuration(

--- a/music/webpack/node.config.ts
+++ b/music/webpack/node.config.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as webpack from 'webpack';
 import * as nodeExternals from 'webpack-node-externals';
 import {baseConfig} from './es6.base.config';
 
@@ -27,4 +28,10 @@ module.exports = {
   },
   // If bundling for Node/Webpack usage, don't bundle node_modules.
   externals: nodeExternals(),
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(
+      /\/core\/timer\.ts/,
+      path.resolve(__dirname, '../src/core/timer_node.ts')
+    ),
+  ]
 };


### PR DESCRIPTION
Fixes https://github.com/magenta/magenta-js/issues/471

Adds a shim module for `window.performance` for Node.js use that's only included during the Node webpack build.