### PR TITLE
Bind fetch to window to eliminate weird fetch issue

### DIFF
--- a/music/src/core/compat/global.ts
+++ b/music/src/core/compat/global.ts
@@ -28,6 +28,6 @@ export interface Performance {
 }
 
 // tslint:disable:no-require-imports
-export const fetch = isNode ? require('node-fetch') as (typeof window.fetch) :  window.fetch;
+export const fetch: typeof window.fetch = isNode ? require('node-fetch') : window.fetch.bind(window);
 export const performance: Performance = isNode ? require('./performance_node') : window.performance;
 export const navigator = isNode ? require('./navigator_node') : window.navigator;

--- a/music/src/core/compat/global_browser.ts
+++ b/music/src/core/compat/global_browser.ts
@@ -18,6 +18,6 @@
  * limitations under the License.
  */
 
-export const fetch = window.fetch;
+export const fetch = window.fetch.bind(window);
 export const performance = window.performance;
 export const navigator = window.navigator;


### PR DESCRIPTION
The ES5 build was throwing the following error when trying to use the `window.fetch` method from the new compat code: 

```
Failed to execute 'fetch' on 'Window': Illegal invocation
```

This is because webpack borks the context of the `fetch` method that's exported from the global compat file, so we need to bind it to `window` before exporting it to have it work properly :/