### PR TITLE
Add global object helpers

### DIFF
--- a/music/src/core/compat/global.ts
+++ b/music/src/core/compat/global.ts
@@ -18,6 +18,12 @@
  * limitations under the License.
  */
 
+/**
+ * This file acts as a stand-in used during development to ensure type safety
+ * and proper use of global functions/objects. We use webpack to swap it out
+ * with the `global_browser` and `global_node` files that export proper code
+ * for the various global functions/objects
+ */
 const isNode = typeof global !== 'undefined';
 
 export interface Performance {
@@ -31,3 +37,5 @@ export interface Performance {
 export const fetch: typeof window.fetch = isNode ? require('node-fetch') : window.fetch.bind(window);
 export const performance: Performance = isNode ? require('./performance_node') : window.performance;
 export const navigator = isNode ? require('./navigator_node') : window.navigator;
+
+export { isSafari, getOfflineAudioContext } from './global_browser';

--- a/music/src/core/compat/global_browser.ts
+++ b/music/src/core/compat/global_browser.ts
@@ -18,6 +18,42 @@
  * limitations under the License.
  */
 
-export const fetch = window.fetch.bind(window);
-export const performance = window.performance;
-export const navigator = window.navigator;
+/**
+ * Attempts to determine which global object to use, depending on whether or
+ * note the script is being used in a browser, web worker, or other context.
+ */
+function getGlobalObject() {
+  // tslint:disable-next-line:max-line-length
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
+  if (typeof globalThis !== 'undefined') { return globalThis; }
+  if (typeof self !== 'undefined') { return self; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  throw new Error('cannot find the global object');
+}
+
+const globalObject = getGlobalObject();
+
+export const fetch = globalObject.fetch.bind(globalObject);
+export const performance = globalObject.performance;
+export const navigator = globalObject.navigator;
+
+// tslint:disable:no-any
+export const isSafari = !!(globalObject as any).webkitOfflineAudioContext;
+// tslint:disable-next-line:no-any variable-name
+const isWorker = typeof (globalObject as any).WorkerGlobalScope !== 'undefined';
+
+export function getOfflineAudioContext(sampleRate: number): OfflineAudioContext {
+  // Safari Webkit only supports 44.1kHz audio.
+  const WEBKIT_SAMPLE_RATE = 44100;
+  sampleRate = isSafari ? WEBKIT_SAMPLE_RATE : sampleRate;
+
+  if (isWorker) {
+    throw new Error('Cannot use offline audio context in a web worker.');
+  }
+
+  // tslint:disable-next-line:no-any variable-name
+  const SafariOfflineCtx = (globalObject as any).webkitOfflineAudioContext;
+  return isSafari ? new SafariOfflineCtx(1, sampleRate, sampleRate) :
+    new globalObject.OfflineAudioContext(1, sampleRate, sampleRate);
+}

--- a/music/src/core/compat/global_node.ts
+++ b/music/src/core/compat/global_node.ts
@@ -22,3 +22,11 @@
 export const fetch = require('node-fetch');
 export const performance = require('./performance_node');
 export const navigator = require('./navigator_node');
+
+export function isSafari(): boolean {
+  throw new Error('Cannot check if Safari in Node.js');
+}
+
+export function getOfflineAudioContext(sampleRate: number): OfflineAudioContext {
+  throw new Error('Cannot use offline audio context in Node.js');
+}


### PR DESCRIPTION
In order to keep fighting the fight of browser/worker/node compatibility of Magenta.js, we need to properly ensure that global objects are provided correctly across the different build environments. Earlier changes had neglected to deal with web workers correctly, so this PR adds a few helper methods to ensure that the global/window/self global object is being used properly in the given setting.

It also adds a few shim methods to help with the OfflineAudioContext global, which will throw more helpful errors when attempting to be used in settings without the context (worker and node).

In the near future, we'll need to set up puppeteer headless browser tests to ensure that all of this is working correctly in all of the different environments that magenta is being used in.