### PR TITLE
Fixed bug with Coconet when running with tfjs-node backend

### DIFF
--- a/music/src/coconet/model.ts
+++ b/music/src/coconet/model.ts
@@ -565,7 +565,8 @@ class Coconet {
             predictions.shape[0], predictions.shape[1], predictions.shape[3],
             predictions.shape[2]
           ])
-          .transpose([0, 1, 3, 2]);
+          .transpose([0, 1, 3, 2])
+          .cast("float32");
     });
   }
 }


### PR DESCRIPTION
There was a weird bug when you use coconet with tfjs-node backend, it required [here](https://github.com/magenta/magenta-js/blob/b149ce62e7b58075e7177d3b33be123fb6706144/music/src/coconet/model.ts#L518) the samples to be casted to float32.

Now it works well with default and node backends.