### PR TITLE
Add offset parameter to player.start

### DIFF
--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -139,11 +139,12 @@ export abstract class BasePlayer {
    * @param qpm (Optional) If specified, will play back at this qpm. If not
    * specified, will use either the qpm specified in the sequence or the
    * default of 120. Only valid for quantized sequences.
+   * @param offset (Optional) The time to start playing from.
    * @returns a Promise that resolves when playback is complete.
    * @throws {Error} If this or a different player is currently playing.
    */
 
-  start(seq: INoteSequence, qpm?: number): Promise<void> {
+  start(seq: INoteSequence, qpm?: number, offset = 0): Promise<void> {
     if (this.getPlayState() === 'started') {
       throw new Error('Cannot start playback; player is already playing.');
     } else if (this.getPlayState() === 'paused') {
@@ -194,7 +195,7 @@ export abstract class BasePlayer {
     if (this.desiredQPM) {
       Tone.Transport.bpm.value = this.desiredQPM;
     }
-    this.currentPart.start();
+    this.currentPart.start(undefined, offset);
     if (Tone.Transport.state !== 'started') {
       Tone.Transport.start();
     }
@@ -541,9 +542,9 @@ export class SoundFontPlayer extends BasePlayer {
     Tone.context.resume();
   }
 
-  start(seq: INoteSequence, qpm?: number): Promise<void> {
+  start(seq: INoteSequence, qpm?: number, offset = 0): Promise<void> {
     this.resumeContext();
-    return this.loadSamples(seq).then(() => super.start(seq, qpm));
+    return this.loadSamples(seq).then(() => super.start(seq, qpm, offset));
   }
 
   protected playNote(time: number, note: NoteSequence.INote) {

--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -195,7 +195,7 @@ export abstract class BasePlayer {
     if (this.desiredQPM) {
       Tone.Transport.bpm.value = this.desiredQPM;
     }
-    this.currentPart.start(undefined, offset);
+    this.currentPart.start(undefined /* immediately */, offset);
     if (Tone.Transport.state !== 'started') {
       Tone.Transport.start();
     }


### PR DESCRIPTION
Adding an `offset` parameter to enable starting the sequence from a given time.

This will allow me to implement a workaround for my [seeking problem in html-midi-player](https://github.com/cifkao/html-midi-player/issues/2). Related: #502.