### PR TITLE
Clean up TS errors

### DIFF
--- a/music/.npmrc
+++ b/music/.npmrc
@@ -1,0 +1,1 @@
+scripts-prepend-node-path=true

--- a/music/src/core/data.ts
+++ b/music/src/core/data.ts
@@ -606,7 +606,7 @@ export class TrioConverter extends DataConverter {
 
   async toNoteSequence(
       th: tf.Tensor2D, stepsPerQuarter?: number, qpm?: number) {
-    const ohs = tf.split(
+    const ohs: tf.Tensor2D[] = tf.split(
         th,
         [
           this.melConverter.depth, this.bassConverter.depth,

--- a/music/src/core/fft.d.ts
+++ b/music/src/core/fft.d.ts
@@ -1,0 +1,1 @@
+declare module 'fft.js';

--- a/music/src/music_rnn/model.ts
+++ b/music/src/music_rnn/model.ts
@@ -320,7 +320,7 @@ export class MusicRNN {
     inputs = inputs.toFloat();
     const samples: tf.Tensor1D[] = [];
     const probs: tf.Tensor1D[] = [];
-    const splitInputs = tf.split(inputs.toFloat(), length);
+    const splitInputs: tf.Tensor2D[] = tf.split(inputs.toFloat(), length);
     const splitControls =
         controls ? tf.split(controls, controls.shape[0]) : undefined;
     const splitAuxInputs =
@@ -362,7 +362,7 @@ export class MusicRNN {
       if (splitAuxInputs) {
         tensors.push(splitAuxInputs[i]);
       }
-      nextInput = tf.concat(tensors, 1);
+      nextInput = tf.concat(tensors, 1) as tf.Tensor2D;
 
       if (this.attentionWrapper) {
         const wrapperOutput =

--- a/music/src/music_vae/model.ts
+++ b/music/src/music_vae/model.ts
@@ -230,7 +230,7 @@ class HierarchicalEncoder extends Encoder {
 
       for (let level = 0; level < this.baseEncoders.length; ++level) {
         const levelSteps = this.numSteps[level];
-        const splitInputs = tf.split(inputs, levelSteps, 1);
+        const splitInputs: tf.Tensor3D[] = tf.split(inputs, levelSteps, 1);
         const embeddings: tf.Tensor2D[] = [];
         for (let step = 0; step < levelSteps; ++step) {
           embeddings.push(this.baseEncoders[level].encode(
@@ -262,7 +262,7 @@ function initLstmCells(
   const lstmCells: tf.LSTMCellFunc[] = [];
   const c: tf.Tensor2D[] = [];
   const h: tf.Tensor2D[] = [];
-  const initialStates =
+  const initialStates: tf.Tensor2D[] =
       tf.split(dense(zToInitStateVars, z).tanh(), 2 * lstmCellVars.length, 1);
   for (let i = 0; i < lstmCellVars.length; ++i) {
     const lv = lstmCellVars[i];
@@ -622,7 +622,7 @@ class ConductorDecoder extends Decoder {
       let initialInput: tf.Tensor2D[] =
           new Array(this.splitDecoder.numDecoders).fill(undefined);
       const dummyInput: tf.Tensor2D = tf.zeros([batchSize, 1]);
-      const splitControls =
+      const splitControls: tf.Tensor2D[] | undefined =
           controls ? tf.split(controls, this.numSteps) : undefined;
       for (let i = 0; i < this.numSteps; ++i) {
         [lstmCell.c, lstmCell.h] =
@@ -1263,7 +1263,8 @@ class MusicVAE {
     const encodedChordProgression = this.dataConverter.SEGMENTED_BY_TRACK ?
         tf.concat2d(
             [
-              this.chordEncoder.encode(constants.NO_CHORD).expandDims(0),
+              this.chordEncoder.encode(constants.NO_CHORD)
+                .expandDims(0) as tf.Tensor2D,
               this.chordEncoder.encodeProgression(
                   chordProgression, numChordSteps - 1)
             ],
@@ -1302,8 +1303,10 @@ class MusicVAE {
       // depthwise.
       const inputsAndControls: tf.Tensor3D[] = [inputTensors];
       if (controlTensor) {
-        inputsAndControls.push(tf.tile(
-            tf.expandDims(controlTensor, 0), [inputTensors.shape[0], 1, 1]));
+        const tiles = tf.tile(
+          tf.expandDims(controlTensor, 0),
+            [inputTensors.shape[0], 1, 1]) as tf.Tensor3D;
+        inputsAndControls.push(tiles);
       }
       const inputTensorsWithControls = tf.concat3d(inputsAndControls, 2);
 

--- a/music/src/piano_genie/model.ts
+++ b/music/src/piano_genie/model.ts
@@ -303,7 +303,7 @@ class PianoGenieBase {
     // Compute logits and sample.
     const [finalState, output]: [LSTMState, number] = tf.tidy(() => {
       // Project feats array through RNN input matrix.
-      let rnnInput = tf.matMul(
+      let rnnInput: tf.Tensor2D = tf.matMul(
         tf.expandDims(rnnInput1d, 0) as tf.Tensor2D,
         this.modelVars[
         'phero_model/decoder/rnn_input/dense/kernel'] as tf.Tensor2D);

--- a/music/src/piano_genie/model_test.ts
+++ b/music/src/piano_genie/model_test.ts
@@ -50,7 +50,7 @@ test('Piano Genie Model Correctness', async (t: test.Test) => {
   const modelWeightsFp = 'src/piano_genie/test_data/stp_iq_auto_dt.json';
   if (!fs.existsSync(modelWeightsFp)) {
     logging.log('Piano Genie model weights not found. Provisional pass.', 'Model Test');
-    t.end();
+    return t.end();
   }
 
   const vars = loadJSONModelWeights(modelWeightsFp);


### PR DESCRIPTION
For whatever reason, a number of TS errors were introduced as we upgraded from tfjs v1 to v2. This PR fixes all of these TS errors, which had been blocking the build step. 

This PR also adds a `.npmrc` file that fixes a mismatch warning between which Node version the node scripts are using.