### PR TITLE
Fix tone version

### DIFF
--- a/music/README.md
+++ b/music/README.md
@@ -61,7 +61,7 @@ there would be a risk of downloading multiple copies on the same page). Here is 
 <head>
   ...
   <!-- You need to bring your own Tone.js for the player, and tfjs for the model -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/13.8.21/Tone.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.58/Tone.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/tensorflow/1.2.8/tf.min.js"></script>
   <!-- Core library, since we're going to use a player -->
   <script src="https://cdn.jsdelivr.net/npm/@magenta/music@^1.0.0/es6/core.js"></script>

--- a/music/build_tests/es6.html
+++ b/music/build_tests/es6.html
@@ -1,15 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
 </head>
+
 <body>
   <h1>Testing es6/ split bundle</h1>
   <div>does mm.Player work? <b id="player">loading...</b></div>
   <div>does MusicVAE work? <b id="musicvae">loading...</b></div>
 </body>
 <!-- You need to bring your own Tone.js and tfjs. -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/tone/13.8.21/Tone.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.58/Tone.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tensorflow/1.2.8/tf.min.js"></script>
 <script src="../es6/core.js"></script>
 <script src="../es6/music_vae.js"></script>
@@ -24,4 +26,5 @@
     document.getElementById('musicvae').textContent = mvae.isInitialized ? 'yes' : 'no';
   });
 </script>
+
 </html>

--- a/music/package.json
+++ b/music/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magenta/music",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Make music with machine learning, in the browser.",
   "main": "es5/index.js",
   "module": "es6/index.js",


### PR DESCRIPTION
Tone.js had a breaking change, magenta.js got updated for it, but the readme didn't, so anyone copy pasting this will get errors.