### PR TITLE
Clean up player and visualizer imports

### DIFF
--- a/music/demos/callback_player.ts
+++ b/music/demos/callback_player.ts
@@ -92,8 +92,8 @@ class MetronomeCallback extends mm.BasePlayerCallback {
       ]
     ];
     this.drumPitchToClass = new Map<number, number>();
-    for (let c = 0; c < mm.data.DEFAULT_DRUM_PITCH_CLASSES.length; ++c) {
-      mm.data.DEFAULT_DRUM_PITCH_CLASSES[c].forEach((p) => {
+    for (let c = 0; c < mm.constants.DEFAULT_DRUM_PITCH_CLASSES.length; ++c) {
+      mm.constants.DEFAULT_DRUM_PITCH_CLASSES[c].forEach((p) => {
         this.drumPitchToClass.set(p, c);
       });
     }

--- a/music/src/core/constants.ts
+++ b/music/src/core/constants.ts
@@ -37,6 +37,26 @@ export const DEFAULT_CHANNEL = 0;
 export const DRUM_CHANNEL = 9;
 export const NON_DRUM_CHANNELS : ReadonlyArray<number> =
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15];
+export const DEFAULT_DRUM_PITCH_CLASSES: number[][] = [
+  // bass drum
+  [36, 35],
+  // snare drum
+  [38, 27, 28, 31, 32, 33, 34, 37, 39, 40, 56, 65, 66, 75, 85],
+  // closed hi-hat
+  [42, 44, 54, 68, 69, 70, 71, 73, 78, 80],
+  // open hi-hat
+  [46, 67, 72, 74, 79, 81],
+  // low tom
+  [45, 29, 41, 61, 64, 84],
+  // mid tom
+  [48, 47, 60, 63, 77, 86, 87],
+  // high tom
+  [50, 30, 43, 62, 76, 83],
+  // crash cymbal
+  [49, 55, 57, 58],
+  // ride cymbal
+  [51, 52, 53, 59, 82]
+];
 
 // Velocity-related constants.
 export const MIN_MIDI_VELOCITY = 0;

--- a/music/src/core/data.ts
+++ b/music/src/core/data.ts
@@ -28,31 +28,11 @@ import * as tf from '@tensorflow/tfjs';
 import {INoteSequence, NoteSequence} from '../protobuf/index';
 
 import * as constants from './constants';
+import {DEFAULT_DRUM_PITCH_CLASSES} from './constants';
 import * as logging from './logging';
 import {Melody, MelodyControl, MelodyRhythm, MelodyShape} from './melodies';
 import * as performance from './performance';
 import * as sequences from './sequences';
-
-export const DEFAULT_DRUM_PITCH_CLASSES: number[][] = [
-  // bass drum
-  [36, 35],
-  // snare drum
-  [38, 27, 28, 31, 32, 33, 34, 37, 39, 40, 56, 65, 66, 75, 85],
-  // closed hi-hat
-  [42, 44, 54, 68, 69, 70, 71, 73, 78, 80],
-  // open hi-hat
-  [46, 67, 72, 74, 79, 81],
-  // low tom
-  [45, 29, 41, 61, 64, 84],
-  // mid tom
-  [48, 47, 60, 63, 77, 86, 87],
-  // high tom
-  [50, 30, 43, 62, 76, 83],
-  // crash cymbal
-  [49, 55, 57, 58],
-  // ride cymbal
-  [51, 52, 53, 59, 82]
-];
 
 export interface MelodyConverterSpec {
   type: 'MelodyConverter';

--- a/music/src/core/data.ts
+++ b/music/src/core/data.ts
@@ -34,6 +34,8 @@ import {Melody, MelodyControl, MelodyRhythm, MelodyShape} from './melodies';
 import * as performance from './performance';
 import * as sequences from './sequences';
 
+export {DEFAULT_DRUM_PITCH_CLASSES};
+
 export interface MelodyConverterSpec {
   type: 'MelodyConverter';
   args: MelodyConverterArgs;

--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -25,10 +25,9 @@ import * as Tone from 'tone';
 import {performance} from '../core/compat/global';
 import {INoteSequence, NoteSequence} from '../protobuf/index';
 
-import {sequences} from '.';
 import * as constants from './constants';
-import {DEFAULT_DRUM_PITCH_CLASSES} from './data';
 import * as soundfont from './soundfont';
+import * as sequences from './sequences';
 
 function compareQuantizedNotes(a: NoteSequence.INote, b: NoteSequence.INote) {
   if (a.quantizedStartStep < b.quantizedStartStep) {
@@ -278,7 +277,7 @@ export abstract class BasePlayer {
 
 /**
  * A singleton drum kit synthesizer with 9 pitch classed defined by
- * data.DEFAULT_DRUM_PITCH_CLASSES.
+ * constants.DEFAULT_DRUM_PITCH_CLASSES.
  */
 class DrumKit {
   private static instance: DrumKit;
@@ -380,9 +379,9 @@ class DrumKit {
   ];
 
   private constructor() {
-    for (let c = 0; c < DEFAULT_DRUM_PITCH_CLASSES.length; ++c) {
+    for (let c = 0; c < constants.DEFAULT_DRUM_PITCH_CLASSES.length; ++c) {
       // class
-      DEFAULT_DRUM_PITCH_CLASSES[c].forEach((p) => {
+      constants.DEFAULT_DRUM_PITCH_CLASSES[c].forEach((p) => {
         this.DRUM_PITCH_TO_CLASS.set(p, c);
       });
     }

--- a/music/src/core/visualizer.ts
+++ b/music/src/core/visualizer.ts
@@ -20,8 +20,9 @@ import * as sr from 'staffrender';
 
 import {INoteSequence, NoteSequence} from '../protobuf/index';
 
-import {logging, sequences} from '.';
 import {MAX_MIDI_PITCH, MIN_MIDI_PITCH} from './constants';
+import * as logging from './logging';
+import * as sequences from './sequences';
 
 const MIN_NOTE_LENGTH = 1;
 


### PR DESCRIPTION
Cleaning up some imports so that `player` and `visualizer` do not depend on TensorFlow.js via other modules.

Combined with #532, this will make it possible to reduce bundle size quite drastically in cases where we don't need TensorFlow (notwaldorf/example-magenta-in-ts#6).