### PR TITLE
Add control change data in `midiToSequenceProto`

### DIFF
--- a/music/src/core/midi_io.ts
+++ b/music/src/core/midi_io.ts
@@ -104,7 +104,24 @@ export function midiToSequenceProto(
       }
     }
 
-    // TODO: Support pitch bends & control changes.
+    const controlChangeValues = Object.values(track.controlChanges);
+    const flattenedControlChangeValues = [].concat.apply([], controlChangeValues);
+    for (const controlChange of flattenedControlChangeValues) {
+      const controlNumber: number = controlChange.number;
+      const time: number = controlChange.time;
+      const controlValue: number = controlChange.value;
+
+      ns.controlChanges.push(NoteSequence.IControlChange.create({
+        time: time,
+        controlNumber: controlNumber,
+        controlValue: controlValue,
+        instrument: instrumentNumber,
+        program: track.instrument.number,
+        isDrum: track.instrument.percussion
+      }));
+    }
+
+    // TODO: Support pitch bends.
   }
 
   return ns;


### PR DESCRIPTION
Currently, control change data is skipped while parsing MIDI data to proto. This PR adds that ability.