### PR TITLE
fix(player): start ignores offset for promise

### DIFF
--- a/music/src/core/player.ts
+++ b/music/src/core/player.ts
@@ -202,7 +202,7 @@ export abstract class BasePlayer {
         if (this.callbackObject) {
           this.callbackObject.stop();
         }
-      }, `+${seq.totalTime}`);
+      }, `+${seq.totalTime - offset}`);
     });
   }
 


### PR DESCRIPTION
This fixes a bug where BasePlayer.start() didn't resolve the returned promise or call the stop callback relative to offset.