### PR TITLE
Fix audible pops/clicks in several soundfont instruments

### DIFF
--- a/music/src/core/soundfont.ts
+++ b/music/src/core/soundfont.ts
@@ -240,6 +240,7 @@ export class Instrument {
                                 .ToneBufferSource({
                                   url: buffer,
                                   fadeOut: this.FADE_SECONDS,
+                                  fadeIn: this.FADE_SECONDS,
                                 })
                                 .connect(output);
       source.stop(startTime + duration + this.FADE_SECONDS);


### PR DESCRIPTION
Fix a bug that causes audible clicks or pops when playing the FRENCH_HORN or STRING_ENSEMBLE_2 soundfonts (as well as several other soundfonts) in the player demo. The issue is caused by a change in the start() method of the Tone.BufferSource object in newer versions of tone.js, which removed the fifth argument that allowed for the passing of a fadeIn value.

To resolve the issue, this commit adds the missing fadeIn value to releaseSource as a property, ensuring that the sound is properly faded in and out without any clicking or popping.